### PR TITLE
Safari should be killed at end of test run

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,22 @@
+var fs = require('fs');
+var path = require('path');
+
 var SafariBrowser = function(baseBrowserDecorator) {
   baseBrowserDecorator(this);
 
   this._getOptions = function(url) {
+    var HTML_TPL = path.normalize(__dirname + '/static/safari.html');
+
+    var data = fs.readFileSync(HTML_TPL);
+    var content = data.toString().replace('%URL%', url);
+    var staticHtmlPath = this._tempDir + '/redirect.html';
+
+    fs.writeFileSync(staticHtmlPath, content);
+
     return [
       '-Wna',
       'Safari',
-      url
+      staticHtmlPath
     ];
   };
 };
@@ -14,7 +25,7 @@ SafariBrowser.prototype = {
   name: 'Safari',
 
   DEFAULT_CMD: {
-    darwin: '/usr/bin/open'
+    darwin: '/Applications/Safari.app/Contents/MacOS/Safari'
   },
   ENV_CMD: 'SAFARI_BIN'
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-safari-launcher",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A Karma plugin. Launcher for Safari.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Calling "open" to launch safari works well to open Safari, but does not allow
Safari to be killed by Karma when it is finished with tests. We can call Safari
directly (and therefore be able to kill the process) by using a local temp file
for redirection to the provided url.
